### PR TITLE
Update the dismantle submodule

### DIFF
--- a/lib/Language/ASL/Translation/Preprocess.hs
+++ b/lib/Language/ASL/Translation/Preprocess.hs
@@ -68,7 +68,7 @@ import           Data.Parameterized.Some ( Some(..) )
 
 import qualified Data.BitMask as BM
 import qualified Dismantle.ARM.ASL as DA ( Encoding(..), FieldConstraint(..) )
-import qualified Dismantle.Tablegen.ByteTrie as BT
+import qualified Dismantle.Tablegen.Patterns as BT
 import qualified Data.Text as T
 import           Data.Traversable (forM)
 import qualified Data.Parameterized.TraversableFC as FC


### PR DESCRIPTION
This makes dismantle build in a reasonable amount of memory.  It does remove the
ByteTrie, so this import has to change.