### PR TITLE
Export an additional type context

### DIFF
--- a/lib/Language/ASL/Globals.hs
+++ b/lib/Language/ASL/Globals.hs
@@ -62,6 +62,7 @@ module Language.ASL.Globals
   , StructGlobalSymsCtx
   , StructGlobalsCtx
   , mapToGlobalsType
+  , SimpleGlobalsCtx
   , GPRCtx
   , SIMDCtx
   -- traversal of an assignment over a globals struct which projects a structured view


### PR DESCRIPTION
This is needed in macaw-aarch32-symbolic