### PR TITLE
Support building with GHC 9.0

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         submodules: 'true'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       id: setup-haskell
       name: Setup Haskell
       with:

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -27,14 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.2']
-        cabal: ['3.2.0.0']
+        ghc: ['8.8.4', '8.10.7', '9.0.2']
+        cabal: ['3.6.2.0']
         os: [ubuntu-latest, macOS-latest]
         exclude:
           - os: macOS-latest
-            ghc: 8.6.5
-          - os: macOS-latest
             ghc: 8.8.4
+          - os: macOS-latest
+            ghc: 8.10.7
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }} asl-translator
 

--- a/asl-translator.cabal
+++ b/asl-translator.cabal
@@ -27,7 +27,7 @@ flag asl-lite
 
 common shared-properties
   default-language:    Haskell2010
-  build-depends:       base >=4.10.0.0 && < 5,
+  build-depends:       base >=4.13.0.0 && < 5,
                        bv-sized >= 1.0.1 && < 1.1,
                        panic >= 0.3,
                        containers,
@@ -54,7 +54,7 @@ common shared-properties
                        split,
                        time,
                        panic >= 0.3,
-                       template-haskell,
+                       template-haskell >= 2.15,
                        th-compat >= 0.1 && < 0.2,
                        vector,
                        directory,

--- a/lib/Data/Parameterized/AssignTree.hs
+++ b/lib/Data/Parameterized/AssignTree.hs
@@ -96,7 +96,7 @@ instance FC.FoldableFC AssignTree where
   foldMapFC = FC.foldMapFCDefault
 
 instance FC.TraversableFC AssignTree where
-  traverseFC = traverseAssignTree
+  traverseFC f = traverseAssignTree f
 
 
 type family FlattenCtxTrees (trees :: Ctx (CtxTree k)) :: Ctx k where

--- a/lib/Data/Parameterized/CtxFuns.hs
+++ b/lib/Data/Parameterized/CtxFuns.hs
@@ -71,11 +71,7 @@ $(do
     natK <- [t| Nat |]
     symbK <- [t| Symbol |]
     tyHead <- return $ TH.TypeFamilyHead natToSymbol [TH.kindedTV n natK] (TH.KindSig symbK) Nothing
-#if MIN_VERSION_template_haskell(2, 15, 0)
     let mkSyn i = TH.TySynEqn Nothing (TH.AppT (TH.ConT natToSymbol) (TH.LitT (TH.NumTyLit i))) (TH.LitT $ TH.StrTyLit (show i))
-#else
-    let mkSyn i = TH.TySynEqn [TH.LitT (TH.NumTyLit i)] (TH.LitT $ TH.StrTyLit (show i))
-#endif
     return $ [TH.ClosedTypeFamilyD tyHead (map mkSyn [0..31])]
  )
 

--- a/lib/Data/Parameterized/CtxFuns.hs
+++ b/lib/Data/Parameterized/CtxFuns.hs
@@ -70,7 +70,7 @@ $(do
     n <- return $ TH.mkName "n"
     natK <- [t| Nat |]
     symbK <- [t| Symbol |]
-    tyHead <- return $ TH.TypeFamilyHead natToSymbol [TH.KindedTV n natK] (TH.KindSig symbK) Nothing
+    tyHead <- return $ TH.TypeFamilyHead natToSymbol [TH.kindedTV n natK] (TH.KindSig symbK) Nothing
 #if MIN_VERSION_template_haskell(2, 15, 0)
     let mkSyn i = TH.TySynEqn Nothing (TH.AppT (TH.ConT natToSymbol) (TH.LitT (TH.NumTyLit i))) (TH.LitT $ TH.StrTyLit (show i))
 #else
@@ -202,7 +202,7 @@ traverseMapCtx p1 f asn = case Ctx.viewAssign asn of
   Ctx.AssignExtend asn' x -> liftA2 (:>) (traverseMapCtx p1 f asn') (f x)
 
 revApplyMapCtx :: forall k1 k2 (f :: TyFun k1 k2 -> Type) (xs :: Ctx k1)
-                         (g :: k2 -> Type) (h :: k1 -> Type) 
+                         (g :: k2 -> Type) (h :: k1 -> Type)
                 . Proxy f -> (forall (x :: k1). g (Apply f x) -> h x)
                -> Ctx.Assignment g (MapCtx f xs)
                -> Ctx.Assignment h xs

--- a/lib/Language/ASL/StaticExpr.hs
+++ b/lib/Language/ASL/StaticExpr.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -222,7 +221,7 @@ staticBinOp bop msv msv' = do
   case bop of
     AS.BinOpEQ -> return $ StaticBool $ sv == sv'
     AS.BinOpNEQ -> return $ StaticBool $ sv /= sv'
-    _ -> fail ""  
+    _ -> fail ""
   <|> do
   StaticInt i <- msv
   StaticInt i' <- msv'
@@ -251,10 +250,10 @@ staticBinOp bop msv msv' = do
     AS.BinOpLogicalAnd -> do
       StaticBool False <- msv
       return $ StaticBool False
-      <|> do       
+      <|> do
       StaticBool False <- msv'
       return $ StaticBool False
-      <|> do      
+      <|> do
       StaticBool True <- msv
       StaticBool True <- msv'
       return $ StaticBool True
@@ -323,7 +322,7 @@ matchMask bv mask =
       (_, AS.MaskBitEither) -> True
       _ -> False
 
--- | Nondeterministic state monad for collecting possible variable assignments. 
+-- | Nondeterministic state monad for collecting possible variable assignments.
 newtype StaticEnvM a = StaticEnvM { getStaticPEnvs :: StaticEnvP -> [(StaticEnvP, a)] }
 
 instance Functor StaticEnvM where
@@ -338,16 +337,12 @@ instance Monad StaticEnvM where
     StaticEnvM (\env -> concat $ map (\(env', ret) -> getStaticPEnvs (g ret) env') (f env))
   return x = StaticEnvM (\env -> [(env, x)])
 
-#if !(MIN_VERSION_base(4,13,0))
-  fail = Fail.fail
-#endif
-
 instance Fail.MonadFail StaticEnvM where
   fail _ = StaticEnvM (\_ -> [])
 
 instance Alternative StaticEnvM where
   empty = Fail.fail ""
-  StaticEnvM x <|> StaticEnvM y = StaticEnvM (\env -> (x env) ++ (y env)) 
+  StaticEnvM x <|> StaticEnvM y = StaticEnvM (\env -> (x env) ++ (y env))
 
 instance MonadPlus StaticEnvM
 
@@ -552,7 +547,7 @@ stmtToStaticM s = case s of
   _ -> return ()
   where
     applyTests tests mfin = case tests of
-      (test, body) : rest -> do    
+      (test, body) : rest -> do
         testExpr test >>= \case
           True -> stmtsToStaticM body
           False -> applyTests rest mfin
@@ -561,7 +556,7 @@ stmtToStaticM s = case s of
         _ -> return ()
 
     casesToTests e = \case
-      (AS.CaseWhen (pat : pats) _ stmts) : rest -> let      
+      (AS.CaseWhen (pat : pats) _ stmts) : rest -> let
         (tests, fin) = casesToTests e rest
         test = foldr (\pat' -> \e' -> AS.ExprBinOp AS.BinOpLogicalOr e' (patToExpr e pat')) (patToExpr e pat) pats
         in ((test, stmts) : tests, fin)


### PR DESCRIPTION
This contains a variety of fixes needed to make `asl-translator` compile with
GHC 9.0:

* GHC 9.0 implements simplified subsumption (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0?version_id=5fcd0a50e0872efb3c38a32db140506da8310d87#simplified-subsumption)).
  This requires manually eta expanding a definition in
  `Data.Parameterized.AssignTree` to accommodate.
* The types of `PlainTV` and `KindedTV` changed in GHC 9.0 (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0?version_id=5fcd0a50e0872efb3c38a32db140506da8310d87#template-haskell-217)).
  The type of `kindedTV` remains the same, so I changed a use of `KindedTV`
  to `kindedTV` to make `Data.Parameterized.CtxFuns` compile.
* The `crucible` submodule has been updated to allow building with GHC 9.0.