### PR TITLE
Fix two minor bugs in `asl-translator-exec`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,21 +33,21 @@ SOURCE_FILES = $(SPEC_FILES:%.sexpr=${PARSED}/%.sexpr)
 
 ./output/instructions.what4 ./output/functions.what4 &:: ${SOURCE_FILES} ${HS_SOURCES}
 	cabal v2-build --builddir=asl-build dismantle-arm-xml -f -asl-lite
-	cabal v2-run --builddir=asl-build asl-translator-exec -f -asl-lite -- --output-functions="./output/functions.what4" --output-instructions="./output/instructions.what4" --asl-spec="${PARSED}/" --parallel
+	cabal v2-run --builddir=asl-build asl-translator-exec -f -asl-lite -- --output-functions="./output/functions.what4" --output-instructions="./output/instructions.what4" --output-global-sigs="./output/global_sigs.txt" --asl-spec="${PARSED}/" --parallel
 
 
 ./output/instructions-lite.what4 ./output/functions-lite.what4 &:: ${SOURCE_FILES} ${HS_SOURCES}
 	cabal v2-build --builddir=asl-lite-build dismantle-arm-xml -f asl-lite
-	cabal v2-run --builddir=asl-lite-build asl-translator-exec -f asl-lite -- --output-functions="./output/functions-lite.what4" --output-instructions="./output/instructions-lite.what4" --asl-spec="${PARSED}/" --parallel
+	cabal v2-run --builddir=asl-lite-build asl-translator-exec -f asl-lite -- --output-functions="./output/functions-lite.what4" --output-instructions="./output/instructions-lite.what4" --output-global-sigs="./output/global_sigs.txt" --asl-spec="${PARSED}/" --parallel
 
 
 ./output/instructions-norm.what4 ./output/functions-norm.what4 &:: ./output/instructions.what4 ./output/functions.what4 ./lib/Language/ASL/Formulas/Normalize.hs
 	cabal v2-build --builddir=asl-build dismantle-arm-xml -f -asl-lite
-	cabal v2-run --builddir=asl-build asl-translator-exec -f -asl-lite -- --output-norm-functions="./output/functions-norm.what4" --output-norm-instructions="./output/instructions-norm.what4" --output-instructions="./output/instructions.what4" --output-functions="./output/functions.what4" --normalize-mode=all
+	cabal v2-run --builddir=asl-build asl-translator-exec -f -asl-lite -- --output-norm-functions="./output/functions-norm.what4" --output-norm-instructions="./output/instructions-norm.what4" --output-instructions="./output/instructions.what4" --output-functions="./output/functions.what4" --output-global-sigs="./output/global_sigs.txt" --normalize-mode=all
 
 ./output/instructions-norm-lite.what4 ./output/functions-norm-lite.what4 &:: ./output/instructions-lite.what4 ./output/functions-lite.what4 ./lib/Language/ASL/Formulas/Normalize.hs
 	cabal v2-build --builddir=asl-lite-build dismantle-arm-xml -f asl-lite
-	cabal v2-run --builddir=asl-lite-build asl-translator-exec -f asl-lite -- --output-norm-functions="./output/functions-norm-lite.what4" --output-norm-instructions="./output/instructions-norm-lite.what4" --output-instructions="./output/instructions-lite.what4" --output-functions="./output/functions-lite.what4" --normalize-mode=all
+	cabal v2-run --builddir=asl-lite-build asl-translator-exec -f asl-lite -- --output-norm-functions="./output/functions-norm-lite.what4" --output-norm-instructions="./output/instructions-norm-lite.what4" --output-instructions="./output/instructions-lite.what4" --output-functions="./output/functions-lite.what4" --output-global-sigs="./output/global_sigs.txt" --normalize-mode=all
 
 ./archived/%.what4.gz: ./output/%.what4
 	gzip --best --stdout $< > $@

--- a/asl-translator.cabal
+++ b/asl-translator.cabal
@@ -34,6 +34,7 @@ common shared-properties
                        constraints,
                        dismantle-arm-xml,
                        dismantle-tablegen,
+                       filepath,
                        hashtables,
                        ilist,
                        integer-logarithms,
@@ -102,7 +103,6 @@ library
 executable asl-translator-exec
   main-is:             Main.hs
   build-depends:       base >=4.10.0.0 && < 5,
-                       filepath,
                        what4-serialize,
                        asl-translator,
                        split,
@@ -117,7 +117,6 @@ test-suite asl-translator-genarm-test
   hs-source-dirs: tests/Translation
   default-language: Haskell2010
   build-depends:       base >= 4.10.0.0 && < 5,
-                       filepath,
                        what4-serialize,
                        asl-translator
   main-is: Main.hs
@@ -140,7 +139,6 @@ executable asl-translator-concrete-test
   main-is: Concrete.hs
   build-depends:       base >= 4.10.0.0 && < 5,
                        bv-sized,
-                       filepath,
                        libBF >= 0.6 && < 0.7,
                        what4-serialize,
                        what4,

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -146,6 +146,10 @@ arguments =
   , Option "p" ["parallel"] (NoArg (Left (\opts -> Just $ opts { optParallel = True  })))
     "Run symbolic simulation concurrently with multiple threads."
 
+  , Option [] ["output-global-sigs"]
+    (ReqArg (\f -> Left (\opts -> Just $ opts { optFilePaths = (optFilePaths opts){ fpOutGlobalSigs = f} })) "PATH")
+   "Path to type signatures for global variables."
+
   , Option [] ["output-functions"]
     (ReqArg (\f -> Left (\opts -> Just $ opts { optFilePaths = (optFilePaths opts){ fpOutFuns = f} })) "PATH")
    "Path to serialized function formulas."


### PR DESCRIPTION
This PR contains two bugfixes:

* Use `(</>)` instead of `(++)` in `L.ASL.Translation.Driver`. This fixes #42.
* Allow overriding `global_sigs.txt`'s location in `asl-translator-exec`. This fixes #43.